### PR TITLE
Add Firefox support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,9 @@ if [ "$browser" != "firefox" ] && [ "$browser" != "firefox-esr" ];then
 else
   rm -rf ~/.config/Zoom-PWA
   mkdir -p ~/.config/Zoom-PWA
+  cp "$DIRECTORY"/ZoomPWA-firefox.zip ~/.config/Zoom-PWA
+  unzip ~/.config/Zoom-PWA/ZoomPWA-firefox.zip
+  mv ~/.config/Zoom-PWA/ZoomPWA-firefox/* ~/.config/Zoom-PWA/
 
 echo "Copying icons to $HOME/.local/share/icons/hicolor ..."
 mkdir -p ~/.local/share/icons/hicolor
@@ -75,14 +78,16 @@ else
   #create menu launcher
   echo "[Desktop Entry]
   Version=1.0
-  Terminal=false
-  Type=Application
-  X-MultipleArgs=false
-  Name=Zoom PWA
+  Name=Zoom PWA test
   Comment=Launch the Zoom Progressive Web App with Firefox
-  Exec=sh -c 'XAPP_FORCE_GTKWINDOW_ICON=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default firefox --class Zoom-PWA --profile ~/.config/Zoom-PWA --no-remote http://pwa.zoom.us/wc'
+  Exec=bash -c 'XAPP_FORCE_GTKWINDOW_ICON=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default firefox --class ZoomPWA --profile /home/pi/.config/ZoomPWA-firefox --no-remote http://pwa.zoom.us/wc'
+  Terminal=false
+  X-MultipleArgs=false
+  Type=Application
   Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
-  Categories=Network;Internet;GTK
+  Categories=GTK;Network;
+  MimeType=text/html;text/xml;application/xhtml_xml;
+  StartupWMClass=ZoomPWA
   StartupNotify=true" >> ~/.local/share/applications/zoom-pwa.desktop
 
 echo 'Done!'

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ else
   #create menu launcher
   echo "[Desktop Entry]
 Version=1.0
-Name=Zoom PWA test
+Name=Zoom PWA
 Comment=Launch the Zoom Progressive Web App with Firefox
 Exec=bash -c 'rm -f $HOME/.config/Zoom-PWA/serviceworker.txt && XAPP_FORCE_GTKWINDOW_ICON=$HOME/.local/share/icons/hicolor/48x48/apps/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default.png $browser_path --class Zoom-PWA --profile $HOME/.config/Zoom-PWA --no-remote https://pwa.zoom.us/wc'
 Terminal=false

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,11 @@ function error {
   exit 1
 }
 
+if [ $(id -u) += "0" ]; then
+  error "This script is not designed to run as root. \nPlease run this script as normal user instead."
+fi
+
+
 if ! command -v git &>/dev/null ;then
   echo "Installing git..."
   sudo apt install -y git
@@ -93,5 +98,7 @@ MimeType=text/html;text/xml;application/xhtml_xml;
 StartupWMClass=ZoomPWA
 StartupNotify=true" > $HOME/.local/share/applications/Zoom-PWA-firefox.desktop
 fi
+
+rm -rf $HOME/zoom-pwa &>/dev/null
 
 echo 'Done!'

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ else
   cp "$DIRECTORY"/ZoomPWA-firefox.zip ~/.config/Zoom-PWA
   unzip ~/.config/Zoom-PWA/ZoomPWA-firefox.zip
   mv ~/.config/Zoom-PWA/ZoomPWA-firefox/* ~/.config/Zoom-PWA/
+fi
 
 echo "Copying icons to $HOME/.local/share/icons/hicolor ..."
 mkdir -p ~/.local/share/icons/hicolor
@@ -61,33 +62,36 @@ if [ "$browser" != "firefox" ] && [ "$browser" != "firefox-esr" ];then
   mkdir -p ~/.local/share/applications
   #create menu launcher
   echo "#!/usr/bin/env xdg-open
-  [Desktop Entry]
-  Version=1.0
-  Terminal=false
-  Type=Application
-  Name=Zoom PWA
-  Comment=Launch the Zoom Progressive Web App with Chromium browser
-  Exec=$browser --user-data-dir=$HOME/.config/Zoom-PWA --profile-directory=Default --app-id=gbmplfifepjenigdepeahbecfkcalfhg --app=https://pwa.zoom.us/wc
-  Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
-  StartupWMClass=crx_gbmplfifepjenigdepeahbecfkcalfhg
-  Categories=Network;WebBrowser;
-  StartupNotify=true" >> ~/.local/share/applications/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Zoom-PWA.desktop
+[Desktop Entry]
+Version=1.0
+Terminal=false
+Type=Application
+Name=Zoom PWA
+Comment=Launch the Zoom Progressive Web App with Chromium browser
+Exec=$browser --user-data-dir=$HOME/.config/Zoom-PWA --profile-directory=Default --app-id=gbmplfifepjenigdepeahbecfkcalfhg --app=https://pwa.zoom.us/wc
+Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
+StartupWMClass=crx_gbmplfifepjenigdepeahbecfkcalfhg
+Categories=Network;WebBrowser;
+StartupNotify=true" >> ~/.local/share/applications/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Zoom-PWA.desktop
+  
 else
   rm -f ~/.local/share/applications/*zoom-pwa*
   mkdir -p ~/.local/share/applications
   #create menu launcher
   echo "[Desktop Entry]
-  Version=1.0
-  Name=Zoom PWA test
-  Comment=Launch the Zoom Progressive Web App with Firefox
-  Exec=bash -c 'XAPP_FORCE_GTKWINDOW_ICON=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default firefox --class ZoomPWA --profile /home/pi/.config/ZoomPWA-firefox --no-remote http://pwa.zoom.us/wc'
-  Terminal=false
-  X-MultipleArgs=false
-  Type=Application
-  Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
-  Categories=GTK;Network;
-  MimeType=text/html;text/xml;application/xhtml_xml;
-  StartupWMClass=ZoomPWA
-  StartupNotify=true" >> ~/.local/share/applications/zoom-pwa.desktop
+Version=1.0
+Name=Zoom PWA test
+Comment=Launch the Zoom Progressive Web App with Firefox
+Exec=bash -c 'XAPP_FORCE_GTKWINDOW_ICON=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default firefox --class ZoomPWA --profile /home/pi/.config/ZoomPWA-firefox --no-remote http://pwa.zoom.us/wc'
+Terminal=false
+X-MultipleArgs=false
+Type=Application
+Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
+Categories=GTK;Network;
+MimeType=text/html;text/xml;application/xhtml_xml;
+StartupWMClass=ZoomPWA
+StartupNotify=true" >> ~/.local/share/applications/zoom-pwa.desktop
+  
+fi
 
 echo 'Done!'

--- a/install.sh
+++ b/install.sh
@@ -28,37 +28,61 @@ elif command -v chromium &>/dev/null;then
   browser="$(command -v chromium)"
 elif command -v google-chrome &>/dev/null;then
   browser="$(command -v google-chrome)"
+elif command -v firefox &>/dev/null;then
+  browser="$(command -v firefox)"
+elif command -v firefox-esr &>/dev/null;then
+  browser="$(command -v firefox-esr)"
 else
-  error "You must have Chromium Browser installed to use the Zoom PWA!"
+  error "You must have Chromium Browser or Firefox installed to use the Zoom PWA!"
 fi
 
 #make chromium config with zoom pre-installed
-echo "Generating Chromium config..."
-rm -rf ~/.config/Zoom-PWA
-mkdir -p ~/.config/Zoom-PWA/Default
-cp "$DIRECTORY"/Preferences ~/.config/Zoom-PWA/Default/Preferences
-echo '' > ~/'.config/Zoom-PWA/First Run'
-sed -i "s+/home/pi+$HOME+g" ~/.config/Zoom-PWA/Default/Preferences
+if [ "$browser" != "firefox" ] && [ "$browser" != "firefox-esr" ];then
+  echo "Generating Chromium config..."
+  rm -rf ~/.config/Zoom-PWA
+  mkdir -p ~/.config/Zoom-PWA/Default
+  cp "$DIRECTORY"/Preferences ~/.config/Zoom-PWA/Default/Preferences
+  echo '' > ~/'.config/Zoom-PWA/First Run'
+  sed -i "s+/home/pi+$HOME+g" ~/.config/Zoom-PWA/Default/Preferences
+else
+  rm -rf ~/.config/Zoom-PWA
+  mkdir -p ~/.config/Zoom-PWA
 
 echo "Copying icons to $HOME/.local/share/icons/hicolor ..."
 mkdir -p ~/.local/share/icons/hicolor
 cp -a "$DIRECTORY"/icons/. ~/.local/share/icons/hicolor
 
 echo "Creating menu launcher..."
-rm -f ~/.local/share/applications/*gbmplfifepjenigdepeahbecfkcalfhg*
-mkdir -p ~/.local/share/applications
-#create menu launcher
-echo "#!/usr/bin/env xdg-open
-[Desktop Entry]
-Version=1.0
-Terminal=false
-Type=Application
-Name=Zoom PWA
-Comment=Launch the Zoom Progressive Web App with Chromium browser
-Exec=$browser --user-data-dir=$HOME/.config/Zoom-PWA --profile-directory=Default --app-id=gbmplfifepjenigdepeahbecfkcalfhg --app=https://pwa.zoom.us/wc
-Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
-StartupWMClass=crx_gbmplfifepjenigdepeahbecfkcalfhg
-Categories=Network;WebBrowser;
-StartupNotify=true" >> ~/.local/share/applications/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Zoom-PWA.desktop
+if [ "$browser" != "firefox" ] && [ "$browser" != "firefox-esr" ];then
+  rm -f ~/.local/share/applications/*gbmplfifepjenigdepeahbecfkcalfhg*
+  mkdir -p ~/.local/share/applications
+  #create menu launcher
+  echo "#!/usr/bin/env xdg-open
+  [Desktop Entry]
+  Version=1.0
+  Terminal=false
+  Type=Application
+  Name=Zoom PWA
+  Comment=Launch the Zoom Progressive Web App with Chromium browser
+  Exec=$browser --user-data-dir=$HOME/.config/Zoom-PWA --profile-directory=Default --app-id=gbmplfifepjenigdepeahbecfkcalfhg --app=https://pwa.zoom.us/wc
+  Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
+  StartupWMClass=crx_gbmplfifepjenigdepeahbecfkcalfhg
+  Categories=Network;WebBrowser;
+  StartupNotify=true" >> ~/.local/share/applications/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Zoom-PWA.desktop
+else
+  rm -f ~/.local/share/applications/*zoom-pwa*
+  mkdir -p ~/.local/share/applications
+  #create menu launcher
+  echo "[Desktop Entry]
+  Version=1.0
+  Terminal=false
+  Type=Application
+  X-MultipleArgs=false
+  Name=Zoom PWA
+  Comment=Launch the Zoom Progressive Web App with Firefox
+  Exec=sh -c 'XAPP_FORCE_GTKWINDOW_ICON=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default firefox --class Zoom-PWA --profile ~/.config/Zoom-PWA --no-remote http://pwa.zoom.us/wc'
+  Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
+  Categories=Network;Internet;GTK
+  StartupNotify=true" >> ~/.local/share/applications/zoom-pwa.desktop
 
 echo 'Done!'

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ DIRECTORY="$(readlink -f "$(dirname "$0")")"
 
 if [ ! -d "$DIRECTORY" ] || [ "$DIRECTORY" == "$HOME" ] || [ "$0" == bash ];then
   echo "Downloading zoom-pwa repo..."
-  rm -rf zoom-pwa
+  rm -rf zoom-pwa || sudo rm -rf zoom-pwa
   git clone https://github.com/Botspot/zoom-pwa || error "failed to git clone!"
   DIRECTORY="$(pwd)/zoom-pwa"
 fi
@@ -45,26 +45,25 @@ fi
 #make chromium config with zoom pre-installed
 if [ "$browser_type" == "chromium" ];then
   echo "Generating Chromium config..."
-  rm -rf ~/.config/Zoom-PWA
-  mkdir -p ~/.config/Zoom-PWA/Default
-  cp "$DIRECTORY"/Preferences ~/.config/Zoom-PWA/Default/Preferences
-  echo '' > ~/'.config/Zoom-PWA/First Run'
-  sed -i "s+/home/pi+$HOME+g" ~/.config/Zoom-PWA/Default/Preferences
+  rm -rf $HOME/.config/Zoom-PWA || sudo rm -rf $HOME/.config/Zoom-PWA
+  mkdir -p $HOME/.config/Zoom-PWA/Default || error "Failed to create $HOME/.config/Zoom-PWA/Default directory!"
+  cp "$DIRECTORY"/Preferences $HOME/.config/Zoom-PWA/Default/Preferences || error "Failed to copy config!"
+  echo '' > $HOME/'.config/Zoom-PWA/First Run'
+  sed -i "s+/home/pi+$HOME+g" $HOME/.config/Zoom-PWA/Default/Preferences
 else
   echo "Generating Firefox config..."
-  rm -rf ~/.config/Zoom-PWA
-  cp "$DIRECTORY"/Zoom-PWA.zip ~/.config/
-  unzip -o ~/.config/Zoom-PWA.zip -d ~/.config
+  rm -rf $HOME/.config/Zoom-PWA || sudo rm -rf $HOME/.config/Zoom-PWA
+  cp "$DIRECTORY"/Zoom-PWA.zip $HOME/.config/ || error "Failed to copy "$DIRECTORY"/Zoom-PWA.zip to $HOME/.config/!"
+  unzip -qo $HOME/.config/Zoom-PWA.zip -d $HOME/.config || error "Failed to unzip config zip!"
 fi
 
 echo "Copying icons to $HOME/.local/share/icons/hicolor ..."
-mkdir -p ~/.local/share/icons/hicolor
-cp -a "$DIRECTORY"/icons/. ~/.local/share/icons/hicolor
+mkdir -p $HOME/.local/share/icons/hicolor
+cp -a "$DIRECTORY"/icons/. $HOME/.local/share/icons/hicolor || error "Failed to copy icons!"
 
 echo "Creating menu launcher..."
 if [ "$browser_type" == "chromium" ];then
-  rm -f ~/.local/share/applications/*gbmplfifepjenigdepeahbecfkcalfhg*
-  mkdir -p ~/.local/share/applications
+  mkdir -p $HOME/.local/share/applications
   #create menu launcher
   echo "[Desktop Entry]
 Version=1.0
@@ -76,8 +75,9 @@ Exec=$browser_path --user-data-dir=$HOME/.config/Zoom-PWA --profile-directory=De
 Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
 StartupWMClass=crx_gbmplfifepjenigdepeahbecfkcalfhg
 Categories=Network;WebBrowser;
-StartupNotify=true" > $HOME/.local/share/applications/chrome-gbmplfifepjenigdepeahbecfkcalfhg-Zoom-PWA.desktop
+StartupNotify=true" > $HOME/.local/share/applications/Zoom-PWA-chromium.desktop
 else
+  mkdir -p $HOME/.local/share/applications
   #create menu launcher
   echo "[Desktop Entry]
 Version=1.0
@@ -91,8 +91,7 @@ Icon=chrome-gbmplfifepjenigdepeahbecfkcalfhg-Default
 Categories=GTK;Network;
 MimeType=text/html;text/xml;application/xhtml_xml;
 StartupWMClass=ZoomPWA
-StartupNotify=true" > $HOME/.local/share/applications/zoom-pwa.desktop
-
+StartupNotify=true" > $HOME/.local/share/applications/Zoom-PWA-firefox.desktop
 fi
 
 echo 'Done!'


### PR DESCRIPTION
Found a way from [Webapp-manager](https://github.com/linuxmint/webapp-manager/) to add firefox support like this:

```
sh -c 'XAPP_FORCE_GTKWINDOW_ICON={icon file} firefox --class Zoom-PWA --profile {config/profile folder} --no-remote http://pwa.zoom.us/wc'
```

Still working, just create this PR to keep track. 

Known bugs:
- Often crash during meeting
- Window title ends with ` - Firefox` (not big deal, just want to be nice)

Currently busy with my [shooting-game](https://github.com/cycool29/shooting-game) project. @Botspot If you have time, you may try to complete the install script (just make `if` `else` statement for chromium and firefox).